### PR TITLE
move msg_id to Connection class; replace tap with tape for testing

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -16,7 +16,6 @@ function Agent(features) {
   var self = this;
   this.features = features;
   this.manifest = {};
-  this._msg_id = 0;
 
   features.forEach(function(f) {
     var meta = f.meta();
@@ -113,8 +112,4 @@ Agent.prototype.shutdown = function(callback) {
   async.forEach(this.features, function(f, callback) {
     f.shutdown(callback);
   }, callback);
-};
-
-Agent.prototype.msg_id = function() {
-  return this._msg_id++;
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -113,7 +113,9 @@ Connection.prototype._connect = function() {
 
 // construct JSON parser/encoding on top of the TLS connection
 Connection.prototype._ready = function() {
+  var msg_id = 0;
   var jsonify = through(function write(o) {
+    o.id = msg_id++;
     try {
       this.queue(JSON.stringify(o) + '\n');
     } catch (e) {

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -23,7 +23,6 @@ function Endpoint(features) {
   var self = this;
   this.features = features;
   this.manifest = {};
-  this._msg_id = 0;
   this.has_consumer = false;
   this.port = 443;
 
@@ -97,8 +96,4 @@ Endpoint.prototype.shutdown = function(callback) {
   async.forEach(this.features, function(f, callback) {
     f.shutdown(callback);
   }, callback);
-};
-
-Endpoint.prototype.msg_id = function() {
-  return this._msg_id++;
 };

--- a/lib/heartbeats.js
+++ b/lib/heartbeats.js
@@ -54,7 +54,6 @@ Heartbeats.prototype.init = function(session, callback) {
 Heartbeats.prototype.heartbeat = function() {
   return {
     v: this.meta().version,
-    id: this.session.msg_id(), // should this be annotated by the connection?
     target: 'heartbeats', // where should the target come from? should it only send if it is supported? should the connection filter that?
     source: this._metadata.name,
     method: 'heartbeat.post',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "logmagic": "~0.1.4"
   },
   "devDependencies": {
-    "tap": "*"
+    "tape": "~2.13.3"
   }
 }


### PR DESCRIPTION
Moving `msg_id` means that features don't need to set `id` field anymore; `Connection` will annotate it. This also changes the scope of `msg_id` from per process to per `Connection`.
