### PR TITLE
Test suite basics, connection port and agent/endpoint shutdown enhancements

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -8,14 +8,15 @@ var FanOut = require('./fan_out');
 var certs = require('./certs');
 var utils = require('./utils');
 
-exports = module.exports = function agent(features) {
-  return new Agent(features);
+exports = module.exports = function agent(features, options) {
+  return new Agent(features, options);
 };
 
-function Agent(features) {
+function Agent(features, options) {
   var self = this;
   this.features = features;
   this.manifest = {};
+  this.options = options || {};
   this._msg_id = 0;
 
   features.forEach(function(f) {
@@ -23,7 +24,8 @@ function Agent(features) {
     self.manifest[meta.name] = meta;
   });  
 
-  this.endpoints = [{'host': 'localhost', 'port': 443 }]; 
+  this.port = this.options.port || 443;
+  this.endpoints = [{'host': 'localhost', 'port': this.port }]; 
 
   // we need to allow the subclass constructor to run 
   // before we create the connection objects
@@ -110,9 +112,23 @@ Agent.prototype._choose_connection = function(data) {
 };
 
 Agent.prototype.shutdown = function(callback) {
-  async.forEach(this.features, function(f, callback) {
-    f.shutdown(callback);
-  }, callback);
+  var self = this;
+
+  async.series([
+    function shutdownFeatures(callback) {
+      async.forEach(self.features, function(f, callback) {
+        f.shutdown(callback);
+      }, callback);
+    },
+
+    function closeConnections(callback) {
+      async.forEach(self.connections, function(c, callback) {
+        c.close(callback);
+      }, callback);
+    }
+  ], function(err) {
+    callback();
+  });
 };
 
 Agent.prototype.msg_id = function() {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,7 @@ var CXN_STATES = {
   READY: 'READY',
   AUTHENTICATED: 'AUTHENTICATED',
   ERROR: 'ERROR',
+  CLOSED: 'CLOSED'
 };
 
 function Connection(manifest, options) {
@@ -196,6 +197,12 @@ Connection.prototype._write = function(chunk, encoding, callback) {
   // since it's the Connecter rather than this.writable that is piped into from
   // upstream stream, we call write() instead of _write() here.
   this.writable.write(chunk, encoding);
+  callback();
+};
+
+Connection.prototype.close = function(callback) {
+  this._changeState(CXN_STATES.CLOSED);
+  this.connection.socket.destroy();
   callback();
 };
 

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -9,8 +9,8 @@ var FanOut = require('./fan_out');
 var certs = require('./certs');
 var utils = require('./utils');
 
-exports = module.exports = function endpoint(features) {
-  var ep = new Endpoint(features);
+exports = module.exports = function endpoint(features, options) {
+  var ep = new Endpoint(features, options);
 
   return ep;
 };
@@ -19,13 +19,14 @@ exports = module.exports = function endpoint(features) {
 
 // TODO: factor Endpoint and Agent to base on same super class?
 
-function Endpoint(features) {
+function Endpoint(features, options) {
   var self = this;
   this.features = features;
+  this.options = options || {};
   this.manifest = {};
   this._msg_id = 0;
   this.has_consumer = false;
-  this.port = 443;
+  this.port = this.options.port || 443;
 
   features.forEach(function(f) {
     var meta = f.meta();
@@ -94,9 +95,21 @@ Endpoint.prototype._choose_connection = function(data) {
 };
 
 Endpoint.prototype.shutdown = function(callback) {
-  async.forEach(this.features, function(f, callback) {
-    f.shutdown(callback);
-  }, callback);
+  var self = this;
+
+  async.series([
+    function shutdownFeatures(callback) {
+      async.forEach(self.features, function(f, callback) {
+        f.shutdown(callback);
+      }, callback);
+    },
+
+    function closeConnections(callback) {
+      self.server.close(callback);
+    }
+  ], function(err) {
+    callback();
+  });
 };
 
 Endpoint.prototype.msg_id = function() {

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "type": "git",
     "url": "https://github.com/virgo-agent-toolkit/virgo.js.git"
   },
+  "scripts": {
+    "test": "node tests/*"
+  },
   "dependencies": {
     "async": "~0.9.0",
+    "logmagic": "~0.1.4",
     "through": "~2.3.4",
-    "underscore": "~1.6.0",
-    "logmagic": "~0.1.4"
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
-    "tap": "*"
+    "tap": "*",
+    "tape": "^2.14.0"
   }
 }

--- a/tests/test_heartbeats.js
+++ b/tests/test_heartbeats.js
@@ -1,0 +1,49 @@
+var test = require('tape');
+var virgo = require('..');
+var async = require('async');
+
+var agent = virgo.agent,
+    endpoint = virgo.endpoint,
+    heartbeats = virgo.heartbeats,
+    portOption = {"port": 8443},
+    tEndpoint, tAgent;
+
+test('send and receive heartbeats test', function(t) {
+  var hbCounter = -1,
+      lastHb = null;
+
+  tEndpoint = endpoint([heartbeats(function(hb) {
+    hbCounter = hbCounter + 1;
+    lastHb = hb;
+  })], portOption);
+  tEndpoint.run();
+  
+  tAgent = agent([heartbeats()], portOption);
+  tAgent.run();
+
+  setTimeout(
+    function() {
+      t.equal(hbCounter, lastHb.id, "heartbeat counter should equal latest heartbeat id");
+      t.end();
+    }, 2000);
+});
+
+test('shutdown heartbeats test', function(t) {
+  t.equal(tAgent.features[0].hb_timer._idleTimeout, 1000, 'Heartbeat timer should be set before agent shutdown');
+  
+  async.series([
+    function shutdownAgent(callback) {
+      tAgent.shutdown(function() {
+        t.equal(tAgent.features[0].hb_timer._idleTimeout, -1, 'Heartbeat timer shouldn\'t be set after agent shutdown');
+        callback();
+      });
+    },
+
+    function shutdownEndpoint(callback) {
+      tEndpoint.shutdown(callback);
+    }
+  ], function(err, callback) {
+    t.notOk(err, 'Shutdown should succeed');
+    t.end();
+  });
+});


### PR DESCRIPTION
The goal of this pull request is to add tests to virgo.js. 
- [x] Adds tape module for testing
- [x] Creates test for heartbeats feature

This PR also offers a couple other enhancements:
- [x] Adds option argument to both agent and endpoint constructors, so that a non-privileged port may be specified
- [x] Enhances shutdown methods of both agents and endpoints so that shutdown occurs gracefully.
