### PR TITLE
Adds handshake and connection source handling

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -17,6 +17,7 @@ function Agent(features, options) {
   this.features = features;
   this.manifest = {};
   this.options = options || {};
+  this.token = options.token || '';
   this._msg_id = 0;
 
   features.forEach(function(f) {
@@ -46,6 +47,7 @@ Agent.prototype.run = function() {
   // map endpoints to connections
   this.connections = this.endpoints.map(function(e) {
     return new Connection(self.manifest, {
+      'agent_token': self.token,
       'endpoint': e,
       'key': certs.client_key,
       'ca': certs.server_cert

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -5,6 +5,8 @@ var stream = require('stream');
 var _ = require('underscore');
 var through = require('through');
 var log = require('logmagic').local('virgojs.connection');
+var pjson = require('../package.json');
+var os = require('os');
 
 var CXN_STATES = {
   INITIAL: 'INITIAL',
@@ -26,6 +28,13 @@ function Connection(manifest, options) {
   this.remote = null;
 
   this.options = options || {};
+  this.token = options.agent_token || '';
+
+  // optional handshake parameter configuration
+  this.source = options.source || os.hostname() + '-' + process.pid;
+  this.agent_id = options.agent_id || os.hostname();
+  this.agent_name = options.agent_name || 'virgo.js';
+  this.process_version = options.process_version || pjson.version;
 
   // This means different behaviors on initiating the connection and during the
   // handshake. Client initiates connection while server listens; clients
@@ -142,17 +151,23 @@ Connection.prototype._ready = function() {
 
 // client (agent) and server (endpoint) handshake and exchange manifest data.
 Connection.prototype._handshake = function() {
-  var self = this;
+  var self = this,
+      msg = self._handshakeMessage(),
+      serverResponse;
+  
   if (this._is_server) {
     var onDataServer = function(data) {
-      if (data.method === 'handshake.post') {
+      if (data.method === 'handshake.hello') {
         self.remote = data.manifest;
-        // TODO
-          if (true) { // if successful
-            self.readable.removeListener('data', onDataServer);
-            self.writable.write(self._handshakeMessage());
-            self._changeState(CXN_STATES.AUTHENTICATED);
-          }
+        self.readable.removeListener('data', onDataServer);
+        serverResponse = {
+          target: msg.source,
+          source: msg.target
+        };
+        msg.target = serverResponse.target;
+        msg.source = serverResponse.source;
+        self.writable.write(msg);
+        self._changeState(CXN_STATES.AUTHENTICATED);
       }
     };
     // using on() instead of once() and let the handler removes itself because
@@ -160,28 +175,41 @@ Connection.prototype._handshake = function() {
     this.readable.on('data', onDataServer);
   } else {
     var onDataClient = function(data) {
-      if (data.method === 'handshake.post') {
-        // TODO
-          self.remote = data.manifest;
-        if (true) { // if successful
-          self.readable.removeListener('data', onDataClient);
-          self._changeState(CXN_STATES.AUTHENTICATED);
+      if (data.id == msg.id && data.source == msg.target && data.target == msg.source) {
+        if (data.v != msg.v) {
+          self._error('Version mismatch: message version and response version do not match');
+          return;
+        } else if (data.error) {
+          self._error(data.error);
+          return;
         }
+        self.remote = data.manifest;
+        self.readable.removeListener('data', onDataClient);
+        self._changeState(CXN_STATES.AUTHENTICATED);
       }
     };
     // using on() instead of once() and let the handler removes itself because
     // incoming message might be non-handshake messages.
     this.readable.on('data', onDataClient);
-    this.writable.write(this._handshakeMessage());
+    this.writable.write(msg);
   }
 };
 
 Connection.prototype._handshakeMessage = function() {
   return {
+    'v': '1',
+    'id': 0,
+    'target': 'endpoint',
+    'source': this.source,
     'manifest': this.manifest,
-    'method': 'handshake.post',
-    // TODO
-      // * normal handsake stuff
+    'method': 'handshake.hello',
+    'params': {
+      'token': this.token,
+      'agent_id': this.agent_id,
+      'agent_name': this.agent_name,
+      'process_version': this.process_version, 
+      'bundle_version': 'n/a' // deprecation incoming
+    }
   };
 };
 
@@ -193,10 +221,11 @@ Connection.prototype._read = function(n) {
   return this.readable._read(n);
 };
 
-Connection.prototype._write = function(chunk, encoding, callback) {
-  // since it's the Connecter rather than this.writable that is piped into from
+Connection.prototype._write = function(obj, encoding, callback) {
+  // since it's the Connection rather than this.writable that is piped into from
   // upstream stream, we call write() instead of _write() here.
-  this.writable.write(chunk, encoding);
+  obj.source = this.source;
+  this.writable.write(obj, encoding);
   callback();
 };
 

--- a/lib/heartbeats.js
+++ b/lib/heartbeats.js
@@ -53,10 +53,9 @@ Heartbeats.prototype.init = function(session, callback) {
 
 Heartbeats.prototype.heartbeat = function() {
   return {
-    v: this.meta().version,
+    v: '1', // This fix is for prod endpoint purposes
     id: this.session.msg_id(), // should this be annotated by the connection?
     target: 'heartbeats', // where should the target come from? should it only send if it is supported? should the connection filter that?
-    source: this._metadata.name,
     method: 'heartbeat.post',
     params: {
       timestamp: new Date().getTime()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgo.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Agent toolkit in node.js",
   "license": "Apache-2",
   "repository": {


### PR DESCRIPTION
## What is this PR?

Adds handshake support and allows agent connections to control the message source.
## How it works
- [x] Adds token parameter to the agent constructor options
- [x] Adds token parameter to Connection constructor options
- [x] Makes Connection handshake message match virgo-base-agent handshake message
- [x] Updates Heartbeat feature metadata to match aep expectation
- [x] Nit: updates virgo.js version to match npm published version
- [x] Fix test breakage
